### PR TITLE
Fix sort error when making tsne

### DIFF
--- a/neat/visualization/visualization.py
+++ b/neat/visualization/visualization.py
@@ -37,7 +37,7 @@ def make_tsne(
     if color_nodes:
         nodes = pd.read_csv(node_file, sep='\t')
         categories = nodes[node_property_for_color]
-        category_names = list(set(categories))
+        category_names = list(set([str(i) for i in categories]))  # coerce to string
         category_names.sort()
         colors = [category_names.index(i) for i in categories]
         cmap = plt.cm.get_cmap('jet', len(category_names))


### PR DESCRIPTION
Fixing this error when doing a tSNE on graph for which some nodes types are not strings:

```
120/120 [==============================] - 461s 4s/step - loss: 12.7450
Traceback (most recent call last):
  File "/usr/local/bin/neat", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/neat/cli.py", line 41, in run
    make_tsne(**tsne_kwargs)
  File "/usr/local/lib/python3.7/dist-packages/neat/visualization/visualization.py", line 41, in make_tsne
    category_names.sort()
TypeError: '<' not supported between instances of 'str' and 'float'
sources.Makefile:64: recipe for target 'neat-hp_mp_baseline_whole_graph' failed
```