### PR TITLE
New options for loading from URLs

### DIFF
--- a/neat/pre_run_checks/pre_run_checks.py
+++ b/neat/pre_run_checks/pre_run_checks.py
@@ -4,6 +4,7 @@ import boto3  # type: ignore
 from botocore.exceptions import ClientError  # type: ignore
 from neat.yaml_helper.yaml_helper import YamlHelper
 
+PREFERRED_FORMATS = ('.tsv', '.tar.gz')
 
 def pre_run_checks(yhelp: YamlHelper,
                    check_s3_credentials: bool = True,
@@ -79,13 +80,13 @@ def pre_run_checks(yhelp: YamlHelper,
             return_val = False
 
     if check_file_extensions and yhelp.main_graph_args():
-        if not (yhelp.main_graph_args()['node_path']).lower().endswith(('.tsv', '.tar.gz')) \
-            or not (yhelp.main_graph_args()['edge_path']).lower().endswith(('.tsv', '.tar.gz')):
+        if not (yhelp.main_graph_args()['node_path']).lower().endswith(PREFERRED_FORMATS) \
+            or not (yhelp.main_graph_args()['edge_path']).lower().endswith(PREFERRED_FORMATS):
             warnings.warn(f"Node or edge file may not be TSV or tar.gz format.")
             return_val = False
 
     if check_file_extensions and yhelp.do_embeddings():
-        if not (yhelp.embedding_outfile()).lower().endswith(('.tsv', '.tar.gz')):
+        if not (yhelp.embedding_outfile()).lower().endswith(PREFERRED_FORMATS):
             warnings.warn(f"Embedding file may not be TSV or tar.gz format.")
             return_val = False
 

--- a/neat/pre_run_checks/pre_run_checks.py
+++ b/neat/pre_run_checks/pre_run_checks.py
@@ -9,6 +9,7 @@ def pre_run_checks(yhelp: YamlHelper,
                    check_s3_credentials: bool = True,
                    check_s3_bucket: bool = True,
                    check_s3_bucket_dir: bool = True,
+                   check_file_extensions: bool = True,
                    ) -> bool:
     """Some checks before run, to prevent frustrating failure at the end of long runs
 
@@ -18,6 +19,8 @@ def pre_run_checks(yhelp: YamlHelper,
             upload dir exists, this will pass
         check_s3_bucket: check that s3 bucket exists on s3
         check_s3_bucket_dir: check that s3 bucket directory doesn't already exist
+        check_file_extensions: check that files are in expected formats (tsv or tar.gz)
+            at least based on their extensions
 
     Returns:
         Boolean pass or fail
@@ -73,6 +76,17 @@ def pre_run_checks(yhelp: YamlHelper,
                     return_val = False
         except ClientError as ce:
             warnings.warn(f"Client error when trying S3 credentials: {ce}")
+            return_val = False
+
+    if check_file_extensions and yhelp.main_graph_args():
+        if not (yhelp.main_graph_args()['node_path']).lower().endswith(('.tsv', '.tar.gz')) \
+            or not (yhelp.main_graph_args()['edge_path']).lower().endswith(('.tsv', '.tar.gz')):
+            warnings.warn(f"Node or edge file may not be TSV or tar.gz format.")
+            return_val = False
+
+    if check_file_extensions and yhelp.do_embeddings():
+        if not (yhelp.embedding_outfile()).lower().endswith(('.tsv', '.tar.gz')):
+            warnings.warn(f"Embedding file may not be TSV or tar.gz format.")
             return_val = False
 
     return return_val

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -1,9 +1,7 @@
-import copy
 import functools
 import logging
 import os
 import string
-import urllib
 from typing import Optional, Callable, Any, Union
 from urllib.request import Request, urlopen
 
@@ -175,8 +173,16 @@ class YamlHelper:
         return 'embeddings' in self.yaml
 
     def embedding_outfile(self) -> str:
-        return os.path.join(self.outdir(),
-                            self.yaml['embeddings']['embedding_file_name'])
+        filepath = self.yaml['embeddings']['embedding_file_name']
+        if is_url(filepath):
+            url_as_filename = \
+                ''.join(c if c in VALID_CHARS else "_" for c in filepath)
+            outfile = os.path.join(self.outdir(), url_as_filename)
+            download_file(filepath, outfile)
+            return outfile
+        else:
+            return os.path.join(self.outdir(),
+                            filepath)
 
     @catch_keyerror
     def embedding_history_outfile(self):

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -135,15 +135,35 @@ class YamlHelper:
     def add_indir_to_graph_data(self, graph_data: dict,
                                 keys_to_add_indir: list = ['node_path', 'edge_path']) -> dict:
         """
+        Updates the graph file paths 
+        with their input directory.
+        Also checks for existence of a 
+        graph_path key. If this exists,
+        download and decompress as needed.
+        The node_path and edge_path values
+        will still need to refer to the
+        node/edge filenames.
         :param graph_data - parsed yaml
         :param keys_to_add_indir: what keys to add indir to
         :return:
         """
+
+        graph_path = 'graph_path'
+
+        if graph_path in graph_data:
+            filepath = graph_data[graph_path]
+            if is_url(filepath):
+                url_as_filename = \
+                    ''.join(c if c in VALID_CHARS else "_" for c in filepath)
+                outfile = os.path.join(self.outdir(), url_as_filename)
+                download_file(filepath, outfile)
+
         for k in keys_to_add_indir:
             if k in graph_data:
                 graph_data[k] = os.path.join(self.indir(), graph_data[k])
             else:
                 logging.warning(f"Can't find key {k} in graph_data - skipping (possibly harmless)")
+        
         return graph_data
 
     #

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -157,6 +157,17 @@ class YamlHelper:
                     ''.join(c if c in VALID_CHARS else "_" for c in filepath)
                 outfile = os.path.join(self.indir(), url_as_filename)
                 download_file(filepath, outfile)
+            # If this was a URL, it already got decompressed.
+            # but if it's local and still compressed, decompress now
+            if filepath.endswith(".tar.gz"):
+                outlist = []
+                decomp_outfile = tarfile.open(filepath)
+                for filename in decomp_outfile.getnames():
+                    outlist.append(os.path.join(self.indir(),filename))
+                if len(outlist) > 2:
+                    logging.warning(f"{outfile} contains than two files.")
+                decomp_outfile.extractall(self.indir())
+                decomp_outfile.close()
 
         for k in keys_to_add_indir:
             if k in graph_data:

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -155,7 +155,7 @@ class YamlHelper:
             if is_url(filepath):
                 url_as_filename = \
                     ''.join(c if c in VALID_CHARS else "_" for c in filepath)
-                outfile = os.path.join(self.outdir(), url_as_filename)
+                outfile = os.path.join(self.indir(), url_as_filename)
                 download_file(filepath, outfile)
 
         for k in keys_to_add_indir:
@@ -185,9 +185,9 @@ class YamlHelper:
             if is_url(filepath):
                 url_as_filename = \
                     ''.join(c if c in VALID_CHARS else "_" for c in filepath)
-                outfile = os.path.join(self.outdir(), url_as_filename)
+                outfile = os.path.join(self.indir(), url_as_filename)
                 download_file(filepath, outfile)
-                graph_args_with_indir[pathtype] = outfile
+                graph_args_with_indir[pathtype] = os.path.join(outfile)
             elif not is_valid_path(filepath):
                 raise FileNotFoundError(f"Please check path: {filepath}")
         

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -73,9 +73,8 @@ def download_file(url: str, outfile: str) -> list:
         outdir = os.path.dirname(outfile)
         for filename in decomp_outfile.getnames():
             outlist.append(os.path.join(outdir,filename))
-        # There should be two files, at most.
         if len(outlist) > 2:
-            raise ValueError(f"{outfile} contains more files than expected!")
+            logging.warning(f"{outfile} contains than two files.")
         decomp_outfile.extractall(outdir)
         decomp_outfile.close()
     else:

--- a/neat/yaml_helper/yaml_helper.py
+++ b/neat/yaml_helper/yaml_helper.py
@@ -73,6 +73,9 @@ def download_file(url: str, outfile: str) -> list:
         outdir = os.path.dirname(outfile)
         for filename in decomp_outfile.getnames():
             outlist.append(os.path.join(outdir,filename))
+        # There should be two files, at most.
+        if len(outlist) > 2:
+            raise ValueError(f"{outfile} contains more files than expected!")
         decomp_outfile.extractall(outdir)
         decomp_outfile.close()
     else:

--- a/tests/resources/test_bad_file_format.yaml
+++ b/tests/resources/test_bad_file_format.yaml
@@ -1,0 +1,25 @@
+---
+graph_data:
+  graph:
+    directed: False
+    node_path: tests/resources/test_graphs/pos_train_nodes.bmp
+    edge_path: tests/resources/test_graphs/pos_train_edges.flac
+    verbose: True
+    nodes_column: 'id'
+    node_list_node_types_column: 'category'
+    default_node_type: 'biolink:NamedThing'
+    sources_column: 'subject'
+    destinations_column: 'object'
+    default_edge_type: 'biolink:related_to'
+
+embeddings:
+  embedding_file_name: test_embeddings_test_yaml.giraffe
+  embedding_history_file_name: embedding_history.json
+  node_embedding_params:
+      node_embedding_method_name: SkipGram # one of 'CBOW', 'GloVe', 'SkipGram', 'Siamese', 'TransE', 'SimplE', 'TransH', 'TransR'
+      walk_length: 10 # typically 100 or so
+      batch_size: 128 # typically 512? or more
+      window_size: 4
+      return_weight: 1.0  # 1/p
+      explore_weight: 1.0  # 1/q
+      iterations: 5 # typically 20

--- a/tests/resources/test_graph_path.yaml
+++ b/tests/resources/test_graph_path.yaml
@@ -1,0 +1,14 @@
+---
+graph_data:
+  graph:
+    directed: False
+    graph_path: graph.tar.gz
+    node_path: nodes.tsv
+    edge_path: edges.tsv
+    verbose: True
+    nodes_column: 'id'
+    node_list_node_types_column: 'category'
+    default_node_type: 'biolink:NamedThing'
+    sources_column: 'subject'
+    destinations_column: 'object'
+    default_edge_type: 'biolink:related_to'

--- a/tests/resources/test_url_for_embeddings.yaml
+++ b/tests/resources/test_url_for_embeddings.yaml
@@ -1,0 +1,11 @@
+embeddings:
+  embedding_file_name: https://someremoteurl.com/embeddings.tsv
+  embedding_history_file_name: embedding_history.json
+  node_embedding_params:
+      node_embedding_method_name: SkipGram
+      walk_length: 10 # typically 100 or so
+      batch_size: 128 # typically 512? or more
+      window_size: 4
+      return_weight: 1.0  # 1/p
+      explore_weight: 1.0  # 1/q
+      iterations: 5 # typically 20

--- a/tests/resources/test_url_for_graph_path.yaml
+++ b/tests/resources/test_url_for_graph_path.yaml
@@ -1,0 +1,14 @@
+---
+graph_data:
+  graph:
+    directed: False
+    graph_path: https://someremoteurl.com/graph.tar.gz
+    node_path: nodes.tsv
+    edge_path: edges.tsv
+    verbose: True
+    nodes_column: 'id'
+    node_list_node_types_column: 'category'
+    default_node_type: 'biolink:NamedThing'
+    sources_column: 'subject'
+    destinations_column: 'object'
+    default_edge_type: 'biolink:related_to'

--- a/tests/test_pre_run_checks.py
+++ b/tests/test_pre_run_checks.py
@@ -34,7 +34,8 @@ class TestPreRunChecks(TestCase):
         mock_boto_client.side_effect = ClientError(error_response=mock_boto_client,
                                                    operation_name=mock_boto_client)
         return_val = pre_run_checks(YamlHelper('tests/resources/test_no_upload.yaml'),
-                                    check_s3_credentials=True)
+                                    check_s3_credentials=True,
+                                    check_file_extensions=False)
         # returns true if bad creds, but we don't have upload key in yaml
         self.assertTrue(return_val)
         self.assertTrue(mock_boto_client.called)
@@ -44,8 +45,15 @@ class TestPreRunChecks(TestCase):
         mock_boto_client.side_effect = ClientError(error_response=mock_boto_client,
                                                    operation_name=mock_boto_client)
         return_val = pre_run_checks(YamlHelper('tests/resources/test_no_upload.yaml'),
-                                    check_s3_credentials=False)
+                                    check_s3_credentials=False,
+                                    check_file_extensions=False)
         # returns true if bad creds, but we don't want to check credentials
         self.assertTrue(return_val)
+    
+    def test_pre_run_check_bad_file_format(self) -> None:
+        return_val = pre_run_checks(YamlHelper('tests/resources/test_bad_file_format.yaml'),
+                                    check_s3_credentials=False,
+                                    check_file_extensions=True)
+        self.assertFalse(return_val)
 
 

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -171,6 +171,19 @@ class TestYamlHelper(TestCase):
         self.assertTrue(mock_download_file.called)
         self.assertEqual(2, mock_download_file.call_count)
 
+    @mock.patch('neat.yaml_helper.yaml_helper.download_file')
+    def test_embeddings_url_converted_to_path(self, mock_download_file):
+        this_yh = YamlHelper('tests/resources/test_url_for_embeddings.yaml')
+        self.assertFalse(is_url(this_yh.embedding_outfile()))
+        self.assertEqual('output_data/https___someremoteurl.com_embeddings.tsv',
+                         this_yh.embedding_outfile())
+
+    @mock.patch('neat.yaml_helper.yaml_helper.download_file')
+    def test_embeddings_url_file_downloaded(self, mock_download_file):
+        this_yh = YamlHelper('tests/resources/test_url_for_embeddings.yaml')
+        this_yh.embedding_outfile()
+        self.assertTrue(mock_download_file.called)
+
     @mock.patch('neat.yaml_helper.yaml_helper.Request')
     @mock.patch('neat.yaml_helper.yaml_helper.urlopen')
     @mock.patch('neat.yaml_helper.yaml_helper.open')

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -157,10 +157,10 @@ class TestYamlHelper(TestCase):
         this_yh.load_graph()
 
         self.assertFalse(is_url(this_yh.main_graph_args()['node_path']))
-        self.assertEqual('output_data/https___someremoteurl.com_nodes.tsv',
+        self.assertEqual('https___someremoteurl.com_nodes.tsv',
                          this_yh.main_graph_args()['node_path'])
         self.assertFalse(is_url(this_yh.main_graph_args()['edge_path']))
-        self.assertEqual('output_data/https___someremoteurl.com_edges.tsv',
+        self.assertEqual('https___someremoteurl.com_edges.tsv',
                          this_yh.main_graph_args()['edge_path'])
 
     @mock.patch('neat.yaml_helper.yaml_helper.download_file')
@@ -170,6 +170,25 @@ class TestYamlHelper(TestCase):
         this_yh.load_graph()
         self.assertTrue(mock_download_file.called)
         self.assertEqual(2, mock_download_file.call_count)
+
+    @mock.patch('neat.yaml_helper.yaml_helper.download_file')
+    @mock.patch('ensmallen.Graph.from_csv')
+    def test_graph_url_converted_to_path(self, mock_from_csv, mock_download_file):
+        this_yh = YamlHelper('tests/resources/test_url_for_graph_path.yaml')
+        self.assertTrue(is_url(this_yh.main_graph_args()['graph_path']))
+        this_yh.main_graph_args()
+        self.assertFalse(is_url(this_yh.main_graph_args()['node_path']))
+        self.assertEqual('nodes.tsv',
+                         this_yh.main_graph_args()['node_path'])
+        self.assertFalse(is_url(this_yh.main_graph_args()['edge_path']))
+        self.assertEqual('edges.tsv',
+                         this_yh.main_graph_args()['edge_path'])
+
+    @mock.patch('neat.yaml_helper.yaml_helper.download_file')
+    def test_graph_url_file_downloaded(self, mock_download_file):
+        this_yh = YamlHelper('tests/resources/test_url_for_graph_path.yaml')
+        this_yh.main_graph_args()
+        self.assertTrue(mock_download_file.called)
 
     @mock.patch('neat.yaml_helper.yaml_helper.download_file')
     def test_embeddings_url_converted_to_path(self, mock_download_file):

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -172,23 +172,26 @@ class TestYamlHelper(TestCase):
         self.assertEqual(2, mock_download_file.call_count)
 
     @mock.patch('neat.yaml_helper.yaml_helper.download_file')
-    @mock.patch('ensmallen.Graph.from_csv')
-    def test_graph_url_converted_to_path(self, mock_from_csv, mock_download_file):
+    @mock.patch('tarfile.open')
+    def test_graph_url_converted_to_path(self, mock_tarfile_open, mock_download_file):
         this_yh = YamlHelper('tests/resources/test_url_for_graph_path.yaml')
-        self.assertTrue(is_url(this_yh.main_graph_args()['graph_path']))
+        self.assertTrue(is_url(this_yh.yaml['graph_data']['graph']['graph_path']))
         this_yh.main_graph_args()
-        self.assertFalse(is_url(this_yh.main_graph_args()['node_path']))
+        self.assertTrue(mock_download_file.called)
+        self.assertTrue(mock_tarfile_open.called)
         self.assertEqual('nodes.tsv',
                          this_yh.main_graph_args()['node_path'])
         self.assertFalse(is_url(this_yh.main_graph_args()['edge_path']))
         self.assertEqual('edges.tsv',
                          this_yh.main_graph_args()['edge_path'])
-
+        
     @mock.patch('neat.yaml_helper.yaml_helper.download_file')
-    def test_graph_url_file_downloaded(self, mock_download_file):
+    @mock.patch('tarfile.open')
+    def test_graph_url_file_downloaded(self, mock_tarfile_open, mock_download_file):
         this_yh = YamlHelper('tests/resources/test_url_for_graph_path.yaml')
         this_yh.main_graph_args()
         self.assertTrue(mock_download_file.called)
+        self.assertTrue(mock_tarfile_open.called)
 
     @mock.patch('neat.yaml_helper.yaml_helper.download_file')
     def test_embeddings_url_converted_to_path(self, mock_download_file):

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -192,3 +192,13 @@ class TestYamlHelper(TestCase):
         for this_mock in [mock_open, mock_urlopen, mock_Request]:
             self.assertTrue(this_mock.called)
             self.assertEqual(1, this_mock.call_count)
+
+    @mock.patch('neat.yaml_helper.yaml_helper.Request')
+    @mock.patch('neat.yaml_helper.yaml_helper.urlopen')
+    @mock.patch('neat.yaml_helper.yaml_helper.open')
+    @mock.patch('tarfile.open')
+    def test_download_compressed_file(self, mock_tarfile_open, mock_open, mock_urlopen, mock_Request):
+        download_file("https://someurl.com/file.tar.gz", outfile="file.tar.gz")
+        for this_mock in [mock_tarfile_open, mock_open, mock_urlopen, mock_Request]:
+            self.assertTrue(this_mock.called)
+            self.assertEqual(1, this_mock.call_count)


### PR DESCRIPTION
Fixes for:
* #62 - can now use a URL in the YAML for `embedding_file_name`
* pre-run checks verify the file extension is one of the expected (for now, that's TSV or tar.gz) for for node/edgelists and embeddings
* Decompress compressed single files when specified in a URL (this does not consider local compressed files - yet)
* #43 - either combined graph.tar.gz or URL to graph.tar.gz specified in new value in YAML, `graph_path`. The values for `node_path` and `edge_path` still need to be present and refer to decompressed `graph_path` contents.