### PR TITLE
Small fix to avoid passing graph_path to Graph loader

### DIFF
--- a/neat/link_prediction/model.py
+++ b/neat/link_prediction/model.py
@@ -63,6 +63,9 @@ class Model:
                                 header=None)
 
         # load graphs
+        # need to remove graph_path if it's present
+        if 'graph_path' in training_graph_args:
+            training_graph_args.pop('graph_path')
         graphs = {'pos_training': Graph.from_csv(**training_graph_args)}
         for name, graph_args in [('pos_validation', pos_validation_args),
                                  ('neg_training', neg_training_args),


### PR DESCRIPTION
Otherwise this raises 
```
TypeError: Graph.from_csv() got an unexpected keyword argument: graph_path
```
upon trying to load the graph data.